### PR TITLE
Fix missing blockheight and incorrect RPC endpoint

### DIFF
--- a/Boba/boba-bnb-starter/src/mappings/mappingHandlers.ts
+++ b/Boba/boba-bnb-starter/src/mappings/mappingHandlers.ts
@@ -27,9 +27,10 @@ export async function handleTransaction(tx: ApproveTransaction): Promise<void> {
 
   const approval = Approval.create({
     id: tx.hash,
+    blockHeight: BigInt(tx.blockNumber),
     owner: tx.from,
-    spender: await tx.args[0],
-    value: BigInt(await tx.args[1].toString()),
+    spender: tx.args[0],
+    value: BigInt(tx.args[1].toString()),
     contractAddress: tx.to,
   });
 

--- a/Boba/boba-eth-starter/project.ts
+++ b/Boba/boba-eth-starter/project.ts
@@ -38,7 +38,7 @@ const project: EthereumProject = {
      * If you use a rate limited endpoint, adjust the --batch-size and --workers parameters
      * These settings can be found in your docker-compose.yaml, they will slow indexing but prevent your project being rate limited
      */
-    endpoint: ["https://bnb.boba.network"],
+    endpoint: ["https://mainnet.boba.network"],
   },
   dataSources: [
     {

--- a/Boba/boba-eth-starter/src/mappings/mappingHandlers.ts
+++ b/Boba/boba-eth-starter/src/mappings/mappingHandlers.ts
@@ -27,9 +27,10 @@ export async function handleTransaction(tx: ApproveTransaction): Promise<void> {
 
   const approval = Approval.create({
     id: tx.hash,
+    blockHeight: BigInt(tx.blockNumber),
     owner: tx.from,
-    spender: await tx.args[0],
-    value: BigInt(await tx.args[1].toString()),
+    spender: tx.args[0],
+    value: BigInt(tx.args[1].toString()),
     contractAddress: tx.to,
   });
 


### PR DESCRIPTION
There are two subquery examples for Boba.  One is for Boba BNB, while the other is for Boba Ethereum.  Both have the same mistakes in the implementation of the mappingHandlers, as both needlessly await on already populated fields and additionally forget to populate the (required) blockHeight field.

Additionally, the Boba Ethereum example re-uses the RPC endpoint for Boba BNB.  Attempting to execute the example will result in a failure due to a chain ID mismatch.

I'm not entirely sure whether this files are the source of, or product of, the `subql init` step, so this might be the wrong spot to submit the PR, if so, please redirect me and I'll be happy to adapt it.

Additionally

https://academy.subquery.network/quickstart/quickstart_chains/boba-bnb.html#add-a-mapping-function

and

https://academy.subquery.network/quickstart/quickstart_chains/boba-eth.html#add-a-mapping-function

likewise need to be regenerated/corrected.